### PR TITLE
PSFs paths / setup fixes

### DIFF
--- a/disk_model/SLD_utils.py
+++ b/disk_model/SLD_utils.py
@@ -6,7 +6,7 @@ import matplotlib.pyplot as plt
 from disk_model.interpolated_univariate_spline import InterpolatedUnivariateSpline
 from astropy.io import fits
 import jax.scipy.signal as jss
-from disk_model.winnie_class import WinniePSF
+import os
 
 class Jax_class:
 
@@ -465,7 +465,7 @@ class EMP_PSF(Jax_class):
         fin_image = np.vectorize(safe_float32_conversion)(fin_image)
         return fin_image
 
-    img = process_image(fits.open("../PSFs/GPI_Hband_PSF.fits")[0].data[0,:,:])
+    img = process_image(fits.open(os.getcwd()+"/PSFs/GPI_Hband_PSF.fits")[0].data[0,:,:])
     
     #define model function and pass independant variables x and y as a list
     @classmethod
@@ -477,6 +477,7 @@ class Winnie_PSF(Jax_class):
     """
     Creates a JWST PSF model, using the package Winnie. See Winnie for further JWST PSF documentation.
     """
+    from disk_model.winnie_class import WinniePSF
     @classmethod
     @partial(jax.jit, static_argnames=['cls', 'num_unique_psfs'])
     def init(cls, psfs, psf_inds_rolls, im_mask_rolls, psf_offsets, psf_parangs, num_unique_psfs):

--- a/disk_model/SLD_utils.py
+++ b/disk_model/SLD_utils.py
@@ -8,6 +8,10 @@ from astropy.io import fits
 import jax.scipy.signal as jss
 import os
 
+os.environ["WEBBPSF_PATH"] = '../webbpsf-data'
+os.environ["WEBBPSF_EXT_PATH"] = '../webbpsf-data'
+os.environ["PYSYN_CDBS"] = "../cdbs"
+
 class Jax_class:
 
     params = {}


### PR DESCRIPTION
the path for the GPI psf was incorrect (that's totally my mistake) so I fixed that / made it more flexible with os.getcwd()

also -- I wanted to use the disk modeling functions without dealing with all the JWST Winnie install stuff, so I moved the winnie psf import line in SLD_utils to the relevant function. I also moved the environment variable definitions from the tutorial into SLD_utils. not sure if this fixes the problem entirely, or if it causes other issues with the JWST functionality, but it would be really nice to not have to install / set up all the JWST stuff unless the user actively wants to use it. I'll open an issue about that!