### PR TITLE
spf variable name changes and pa docstrings

### DIFF
--- a/disk_model/SLD_ojax.py
+++ b/disk_model/SLD_ojax.py
@@ -29,7 +29,11 @@ class ScatteredLightDisk(Jax_class):
             pixel field of view in arcsec/px (default the SPHERE pixel
             scale 0.01225 arcsec/px)
         pa : float
-            position angle of the disc in degrees (default 0 degrees, e.g. North)
+            position angle of the disc in degrees; 
+            here, PA is defined as the angle starting at North (positive y-axis) and moving counter-clockwise
+            toward the projected major axis of the disk such that PA - 90 deg = the PA of the projected semiminor axis of the disk's
+            presumed front side, where front is chosen to be the brightest. This is offset by 180 degrees from conventions in Esposito+ 2020,
+            and is consistent with the convention used in the disk forward modeling functionality of VIP.
         distr_params : dict
             Parameters describing the dust density distribution function
             to be implemented. By default, it uses a two-power law dust

--- a/disk_model/SLD_utils.py
+++ b/disk_model/SLD_utils.py
@@ -270,35 +270,35 @@ class InterpolatedUnivariateSpline_SPF(Jax_class):
 
     Parameters
     ----------
-    low_bound: float
-        cosine of lower bound on scattering angle used for the spline
-    up_bound: float
-        cosine of upper bound on scattering angle used for the spline
+    backscatt_bound: float
+        cosine of bound on back scattering (closer to 180 deg) scattering angle used for the spline
+    forwardscatt_bound: float
+        cosine of bound on forward scattering (closer to 0 deg) scattering angle used for the spline
     num_knots: int
         number of knots
     knot_values: array
         y values of the knots
     """
 
-    params = {'low_bound': -1, 'up_bound': 1, 'num_knots': 6, 'knot_values': jnp.ones(6)}
+    params = {'backscatt_bound': -1, 'forwardscatt_bound': 1, 'num_knots': 6, 'knot_values': jnp.ones(6)}
 
     @classmethod
     @partial(jax.jit, static_argnums=(0))
-    def init(cls, p_arr, knots = jnp.linspace(1, -1, 6)):
+    def init(cls, p_arr, knots = jnp.linspace(1,-1,6)):
         """
         """
         return cls.pack_pars(p_arr, knots=knots)
     
     @classmethod
     def get_knots(cls, p_dict):
-        return jnp.linspace(p_dict['up_bound'], p_dict['low_bound'], p_dict['num_knots'])
+        return jnp.linspace(p_dict['forwardscatt_bound'], p_dict['backscatt_bound'], p_dict['num_knots'])
 
     @classmethod
     @partial(jax.jit, static_argnums=(0))
     def pack_pars(cls, p_arr, knots = jnp.linspace(1, -1, 6)):
         """
         This function takes a array of (knots) values and converts them into an InterpolatedUnivariateSpline model.
-        Also has inclination bounds which help narrow the spline fit --- does it?? where does this happen? should jnp.linspace in the kwargs be replace with up bound, low bound?
+        Also has inclination bounds which help narrow the spline fit
         """    
         return InterpolatedUnivariateSpline(knots, p_arr)
     
@@ -320,83 +320,7 @@ class InterpolatedUnivariateSpline_SPF(Jax_class):
         """
         
         return spline_model(cos_phi)
-    
-# Uses 5 knots by default (1 knot is added at (cos(90 degrees), 1))
-# Values must be cos(phi) not phi
-class FixedInterpolatedUnivariateSpline_SPF(InterpolatedUnivariateSpline_SPF):
-    """
-    Implementation of a spline scattering phase function. Uses 6 knots by default, takes knot y values as parameters.
-    Locations are fixed to the given knots, pack_pars and init both return the spline model itself. 
-    Uses 5 knots by default (1 knot is added at (cos(90 degrees), 1))
 
-    Parameters
-    ----------
-    low_bound: float
-        cosine of lower bound on scattering angle used for the spline
-    up_bound: float
-        cosine of upper bound on scattering angle used for the spline
-    num_knots: int
-        number of knots
-    knot_values: array
-        y values of the knots
-    """
-
-    params = {'low_bound': -1, 'up_bound': 1, 'num_knots': 6, 'knot_values': jnp.ones(6)}
-
-    @classmethod
-    @partial(jax.jit, static_argnums=(0))
-    def init(cls, p_arr, knots = jnp.linspace(1, -1, 6)):
-        """
-        """
-        return cls.pack_pars(p_arr, knots=knots)
-    
-    @classmethod
-    def get_knots(cls, p_dict):
-        if p_dict['num_knots'] % 2 == 1:
-            raise ValueError(f"Number of knots: {p_dict['num_knots']} must be an even number.")
-        else:
-            full = jnp.linspace(p_dict['up_bound'], p_dict['low_bound'], p_dict['num_knots'] + 1)
-            mid_idx = jnp.argmin(jnp.abs(full))  # closest to 0
-            return jnp.concatenate([full[:mid_idx], full[mid_idx+1:]])
-
-    @classmethod
-    @partial(jax.jit, static_argnums=(0))
-    def pack_pars(cls, p_arr, knots = jnp.linspace(1, -1, 6), fixed_val = 1.0):
-        """
-        This function takes a array of (knots) values and converts them into an InterpolatedUnivariateSpline model.
-        Also has inclination bounds which help narrow the spline fit
-        """
-
-        # Add the point (0, 1)
-        knots_aug = jnp.append(knots, jnp.atleast_1d(0.0)) # Only fixed at 90 degrees
-        p_arr_aug = jnp.append(p_arr, jnp.atleast_1d(fixed_val))
-
-        # Sort based on x values
-        sort_idx = jnp.argsort(knots_aug)
-        knots_sorted = knots_aug[sort_idx]
-        p_arr_sorted = p_arr_aug[sort_idx]
-
-        return InterpolatedUnivariateSpline(knots_sorted, p_arr_sorted)
-    
-    @classmethod
-    @partial(jax.jit, static_argnums=(0))
-    def compute_phase_function_from_cosphi(cls, spline_model, cos_phi):
-        """
-        Compute the phase function at (a) specific scattering scattering
-        angle(s) phi. The argument is not phi but cos(phi) for optimization
-        reasons.
-
-        Parameters
-        ----------
-        spline_model : InterpolatedUnivariateSpline
-            spline model to represent scattering light phase function
-        cos_phi : float or array
-            cosine of the scattering angle(s) at which the scattering function
-            must be calculated.
-        """
-        
-        return spline_model(cos_phi)
-    
 
 class GAUSSIAN_PSF(Jax_class):
 

--- a/optimization/optimize_framework.py
+++ b/optimization/optimize_framework.py
@@ -161,7 +161,7 @@ class Optimizer:
                 self.spf_params['num_knots'] = 4
             else:
                 self.spf_params['num_knots'] = 6
-        self.spf_params['up_bound'] = jnp.cos(jnp.deg2rad(90-self.disk_params['inclination']-buffer))
+        self.spf_params['forwardscatt_bound'] = jnp.cos(jnp.deg2rad(90-self.disk_params['inclination']-buffer))
         self.spf_params['low_bound'] = jnp.cos(jnp.deg2rad(90+self.disk_params['inclination']+buffer))
         return self.spf_params
     
@@ -184,14 +184,14 @@ class Optimizer:
             
         self.spf_params['knot_values'] = self.spf_params['knot_values'] * knot_scale
 
-        if self.FuncModel == FixedInterpolatedUnivariateSpline_SPF:
-            adjust_scale = 1.0 / InterpolatedUnivariateSpline_SPF.compute_phase_function_from_cosphi(
-                InterpolatedUnivariateSpline_SPF.init(self.spf_params['knot_values'], InterpolatedUnivariateSpline_SPF.get_knots(self.spf_params)),
-                0.0)
-            self.spf_params['knot_values'] = self.spf_params['knot_values'] * adjust_scale
-            self.misc_params['flux_scaling'] = self.misc_params['flux_scaling'] / adjust_scale
-        else:
-            self.scale_spline_to_fixed_point(0, 1)
+        #if self.FuncModel == FixedInterpolatedUnivariateSpline_SPF:
+            #adjust_scale = 1.0 / InterpolatedUnivariateSpline_SPF.compute_phase_function_from_cosphi(
+                #InterpolatedUnivariateSpline_SPF.init(self.spf_params['knot_values'], InterpolatedUnivariateSpline_SPF.get_knots(self.spf_params)),
+                #0.0)
+            #self.spf_params['knot_values'] = self.spf_params['knot_values'] * adjust_scale
+            #self.misc_params['flux_scaling'] = self.misc_params['flux_scaling'] / adjust_scale
+        #else:
+        self.scale_spline_to_fixed_point(0, 1)
 
     def scale_spline_to_fixed_point(self, cosphi, spline_val):
         adjust_scale = spline_val / InterpolatedUnivariateSpline_SPF.compute_phase_function_from_cosphi(


### PR DESCRIPTION
1. spf_params['up_bound'] --> spf_params['forwardscatt_bound']
2. spf_params['low_bound'] --> spf_params['backscatt_bound']
3. added PA docstring to make things abundantly clear what convention we're using
4. removed FixedInterpolatedSpline_SPF because it was outdated

copying my notes in Slack here to explain why I made these changes:

- spf_params['up_bound']  corresponds to cos(0)=1 or is constrained by inclination to <90 -- meaning this is the forward scattering side of things
- spf_params['low_bound'] corresponds to cos(180)=-1 or is constrained by inclination to >90 -- meaning this is the back scattering side of things
- the phase function appears to default to x values of jnp.linspace(1,-1,6) or equivalently jnp.linspace(up_bound,low_bound,num_knots --> so it appears that the phase function array is in fact in order from x = 0 to x = 180

PA is defined in Esposito et al 2020 as "the angle measured eastward (i.e., counterclockwise in our images) from north to the projected major axis such that 90° + PA is the PA of the projected semiminor axis on the disk’s presumed front side (with “front” chosen here to be the brightest side in Qphi". Our values appear to be offset by 180 relative to the Esposito+ 2020 values. for example, HD145560 has a PA ~41.5 in Esposito+ 2020, whereas GRaTer-JAX calls this PA ~ 221.5
that means our PAs are counterclockwise from south to the same point on the disk as described in tom's paper. alternatively, you could describe this as "north through east to the projected major axis such that PA-90 is the PA of the projected semiminor axis" I think. It appears that this is how VIP defines things too -- given that, I think it may be worthwhile to leave things as is, and just make sure there is clear documentation about this somewhere (everyone defines PA a little differently somehow anyways)